### PR TITLE
adds vertical separator colors

### DIFF
--- a/smyck.vim
+++ b/smyck.vim
@@ -47,6 +47,8 @@ hi MatchParen           cterm=none ctermbg=6        ctermfg=15      gui=none    
 hi CursorLine           cterm=none ctermbg=238      ctermfg=none    gui=none        guibg=#424242
 hi CursorColumn         cterm=none ctermbg=238      ctermfg=none    gui=none        guibg=#424242
 hi Title                cterm=none ctermbg=none     ctermfg=4       gui=none                        guifg=#88CCE7
+hi VertSplit            cterm=bold ctermbg=none     ctermfg=8       gui=bold        guibg=#282828   guifg=#8F8F8F
+hi SignColumn           cterm=bold ctermbg=none     ctermfg=8       gui=bold        guibg=#282828   guifg=#8F8F8F
 
 " ----------------------------------------------------------------------------
 " Syntax Highlighting


### PR DESCRIPTION
adds colors for vertical splits and sign columns to hide white
backgrounds. plugins like gitgutter use sign columns and vertical splits
are notable when using nerdtree, gundo or simply splitting a file
![vertlines](https://cloud.githubusercontent.com/assets/734348/2676173/85eed43a-c130-11e3-8063-6c4c1ce15442.png)
